### PR TITLE
Add scaffold for AI Agent Builder UI

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,7 +1,50 @@
 <script>
-  let name = 'world';
+  import Home from './lib/Home.svelte';
+  import AgentWorkspace from './lib/AgentWorkspace.svelte';
+  import { agents, currentView, currentAgent, createNewAgent, openAgent } from './stores.js';
 </script>
 
-<main class="p-8 text-center">
-  <h1 class="text-3xl font-bold text-blue-500">Hello {name}!</h1>
-</main>
+<div class="flex h-screen">
+  <aside class="w-64 bg-gray-100 p-4 space-y-4">
+    <button class="bg-blue-500 text-white w-full py-2 rounded" on:click={createNewAgent}>
+      Create New Agent
+    </button>
+    <div>
+      <h2 class="font-semibold mb-2">Agents</h2>
+      <ul class="space-y-1">
+        {#each $agents as agent}
+          <li>
+            <button
+              class="text-left w-full p-1 rounded hover:bg-gray-200"
+              on:click={() => openAgent(agent)}
+            >
+              {agent.name}
+            </button>
+          </li>
+        {/each}
+      </ul>
+    </div>
+    <div>
+      <h2 class="font-semibold mb-2">Reusable Library</h2>
+      <div class="text-sm text-gray-500">Configs, Credentials, Tools</div>
+    </div>
+  </aside>
+  <div class="flex-1 flex flex-col">
+    <header class="flex items-center p-4 border-b">
+      <div class="font-bold">Agent Builder</div>
+      <input type="text" placeholder="Search" class="border p-1 rounded flex-1 mx-4" />
+      <div class="rounded-full bg-gray-300 w-8 h-8"></div>
+    </header>
+    <main class="flex-1 overflow-y-auto">
+      {#if $currentView === 'home'}
+        <Home />
+      {:else}
+        <AgentWorkspace />
+      {/if}
+    </main>
+    <footer class="p-4 border-t text-sm text-gray-500 flex justify-between">
+      <div>Version 0.1</div>
+      <a href="/" class="text-blue-500">Help</a>
+    </footer>
+  </div>
+</div>

--- a/src/lib/AgentWorkspace.svelte
+++ b/src/lib/AgentWorkspace.svelte
@@ -1,0 +1,86 @@
+<script>
+  import { currentAgent } from '../stores.js';
+  import MetadataTab from './tabs/MetadataTab.svelte';
+  import DataIntegrationsTab from './tabs/DataIntegrationsTab.svelte';
+  import LLMConfigTab from './tabs/LLMConfigTab.svelte';
+  import QueryingGuidanceTab from './tabs/QueryingGuidanceTab.svelte';
+  import TestingTab from './tabs/TestingTab.svelte';
+  import EvaluationsTab from './tabs/EvaluationsTab.svelte';
+  import MonitoringTab from './tabs/MonitoringTab.svelte';
+
+  let activeTab = 'Metadata';
+
+  const tabs = [
+    { name: 'Metadata', component: MetadataTab, required: false },
+    { name: 'Data Integrations', component: DataIntegrationsTab, required: false },
+    { name: 'LLM Config', component: LLMConfigTab, required: true },
+    { name: 'Querying Guidance', component: QueryingGuidanceTab, required: false },
+    { name: 'Testing', component: TestingTab, required: false },
+    { name: 'Evaluations', component: EvaluationsTab, required: false },
+    { name: 'Monitoring', component: MonitoringTab, required: false }
+  ];
+</script>
+
+{#if $currentAgent}
+  <div class="flex flex-col h-full">
+    <header class="flex justify-between items-center p-4 border-b">
+      <div class="font-semibold text-lg">Agent Name: {$currentAgent.name}</div>
+      <div class="flex items-center space-x-4">
+        <button class="bg-green-500 text-white px-3 py-1 rounded">Deploy</button>
+        <span class="text-sm text-gray-500">Saved</span>
+      </div>
+    </header>
+    <nav class="border-b">
+      <ul class="flex space-x-4 px-4">
+        {#each tabs as t}
+          <li>
+            <button
+              class="py-2 {activeTab === t.name ? 'border-b-2 border-blue-500' : ''}"
+              on:click={() => (activeTab = t.name)}
+            >
+              {t.name}{t.required ? '*' : ''}
+            </button>
+          </li>
+        {/each}
+      </ul>
+    </nav>
+    <div class="flex flex-1 overflow-hidden">
+      <div class="flex-1 overflow-y-auto p-4">
+        {#if activeTab === 'Metadata'}
+          <MetadataTab />
+        {:else if activeTab === 'Data Integrations'}
+          <DataIntegrationsTab />
+        {:else if activeTab === 'LLM Config'}
+          <LLMConfigTab />
+        {:else if activeTab === 'Querying Guidance'}
+          <QueryingGuidanceTab />
+        {:else if activeTab === 'Testing'}
+          <TestingTab />
+        {:else if activeTab === 'Evaluations'}
+          <EvaluationsTab />
+        {:else if activeTab === 'Monitoring'}
+          <MonitoringTab />
+        {/if}
+      </div>
+      <aside class="w-64 border-l p-4 hidden md:block">
+        <h3 class="font-semibold mb-2">Version History</h3>
+        <ul class="text-sm space-y-1 mb-4">
+          <li>Initial draft</li>
+          <li>Updated config</li>
+        </ul>
+        <h3 class="font-semibold mb-2">Quick Links</h3>
+        <ul class="text-sm space-y-1">
+          {#each tabs as t}
+            <li>
+              <button class="text-blue-500" on:click={() => (activeTab = t.name)}>
+                {t.name}
+              </button>
+            </li>
+          {/each}
+        </ul>
+      </aside>
+    </div>
+  </div>
+{:else}
+  <p class="p-4">No agent selected.</p>
+{/if}

--- a/src/lib/Home.svelte
+++ b/src/lib/Home.svelte
@@ -1,0 +1,26 @@
+<script>
+  import { agents, createNewAgent, openAgent } from '../stores.js';
+</script>
+
+<div class="p-8">
+  <h1 class="text-2xl mb-4">Welcome to Agent Builder</h1>
+  <button
+    class="bg-blue-500 text-white px-4 py-2 rounded mb-8"
+    on:click={createNewAgent}
+  >
+    Create New Agent
+  </button>
+  <h2 class="text-xl mb-2">Recent Agents</h2>
+  <div class="grid grid-cols-2 gap-4">
+    {#each $agents as agent}
+      <button
+        class="border p-4 rounded hover:bg-gray-50 text-left"
+        on:click={() => openAgent(agent)}
+      >
+        <h3 class="font-semibold">{agent.name}</h3>
+        <p class="text-sm">{agent.description}</p>
+        <p class="text-xs text-gray-500">Status: {agent.status}</p>
+      </button>
+    {/each}
+  </div>
+</div>

--- a/src/lib/tabs/DataIntegrationsTab.svelte
+++ b/src/lib/tabs/DataIntegrationsTab.svelte
@@ -1,0 +1,58 @@
+<div class="space-y-8">
+  <section>
+    <h2 class="font-semibold mb-2">Data Store Connection</h2>
+    <div class="space-y-2 max-w-md">
+      <div>
+        <label for="conn-type" class="block text-sm">Type</label>
+        <select id="conn-type" class="border p-2 w-full">
+          <option>SurrealDB</option>
+          <option>PostgreSQL</option>
+        </select>
+      </div>
+      <div class="grid grid-cols-2 gap-2">
+        <div>
+          <label for="conn-host" class="block text-sm">Host</label>
+          <input id="conn-host" class="border p-2 w-full" />
+        </div>
+        <div>
+          <label for="conn-port" class="block text-sm">Port</label>
+          <input id="conn-port" class="border p-2 w-full" />
+        </div>
+        <div>
+          <label for="conn-user" class="block text-sm">Username</label>
+          <input id="conn-user" class="border p-2 w-full" />
+        </div>
+        <div>
+          <label for="conn-pass" class="block text-sm">Password</label>
+          <input id="conn-pass" type="password" class="border p-2 w-full" />
+        </div>
+      </div>
+      <button class="bg-green-500 text-white px-3 py-1 rounded">Test Connection</button>
+    </div>
+  </section>
+
+  <section>
+    <h2 class="font-semibold mb-2">Tools</h2>
+    <button class="bg-blue-500 text-white px-3 py-1 rounded">Add Tool</button>
+    <table class="w-full mt-4 text-sm">
+      <thead>
+        <tr class="border-b">
+          <th class="text-left p-1">Name</th>
+          <th class="text-left p-1">Type</th>
+          <th class="p-1">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="p-1">Example Tool</td>
+          <td class="p-1">Query</td>
+          <td class="p-1 text-center">Edit/Delete</td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="mt-2">
+      <label for="reuse-tool" class="block text-sm">Reuse from Library</label>
+      <select id="reuse-tool" class="border p-2 w-full"><option>None</option></select>
+    </div>
+  </section>
+</div>

--- a/src/lib/tabs/EvaluationsTab.svelte
+++ b/src/lib/tabs/EvaluationsTab.svelte
@@ -1,0 +1,51 @@
+<script>
+  let testCases = [];
+  let promptInput = '';
+  let expected = '';
+
+  function addCase() {
+    if (!promptInput) return;
+    testCases = [...testCases, { prompt: promptInput, expected, result: '' }];
+    promptInput = '';
+    expected = '';
+  }
+
+  function runAll() {
+    testCases = testCases.map(c => ({ ...c, result: 'Pass' }));
+  }
+</script>
+
+<div class="space-y-4">
+  <div>
+    <button class="bg-blue-500 text-white px-3 py-1 rounded" on:click={addCase}>
+      Add Test Case
+    </button>
+    <div class="mt-2 space-y-2">
+      <input class="border p-2 w-full" placeholder="Prompt" bind:value={promptInput} />
+      <input class="border p-2 w-full" placeholder="Expected" bind:value={expected} />
+    </div>
+  </div>
+  <div>
+    <button class="bg-green-500 text-white px-3 py-1 rounded" on:click={runAll}>
+      Run All
+    </button>
+  </div>
+  <table class="w-full text-sm">
+    <thead>
+      <tr class="border-b">
+        <th class="text-left p-1">Prompt</th>
+        <th class="text-left p-1">Expected</th>
+        <th class="text-left p-1">Result</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each testCases as c}
+        <tr class="border-b">
+          <td class="p-1">{c.prompt}</td>
+          <td class="p-1">{c.expected}</td>
+          <td class="p-1">{c.result}</td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>

--- a/src/lib/tabs/LLMConfigTab.svelte
+++ b/src/lib/tabs/LLMConfigTab.svelte
@@ -1,0 +1,35 @@
+<div class="space-y-8 max-w-xl">
+  <section>
+    <h2 class="font-semibold mb-2">Provider Credentials</h2>
+    <button class="bg-blue-500 text-white px-3 py-1 rounded mb-2">Create New</button>
+    <div>
+      <label for="reuse-cred" class="block text-sm">Reuse Existing</label>
+      <select id="reuse-cred" class="border p-2 w-full"><option>Choose...</option></select>
+    </div>
+    <table class="w-full mt-4 text-sm">
+      <thead>
+        <tr class="border-b">
+          <th class="text-left p-1">Provider</th>
+          <th class="text-left p-1">Key</th>
+          <th class="p-1">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="p-1">OpenAI</td>
+          <td class="p-1">••••••</td>
+          <td class="p-1 text-center">Edit/Delete</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+  <section>
+    <h2 class="font-semibold mb-2">Model Selection</h2>
+    <label for="model" class="block text-sm">Models</label>
+    <select id="model" class="border p-2 w-full mb-2">
+      <option>GPT-4</option>
+      <option>Claude</option>
+    </select>
+    <button class="bg-green-500 text-white px-3 py-1 rounded">Test Integration</button>
+  </section>
+</div>

--- a/src/lib/tabs/MetadataTab.svelte
+++ b/src/lib/tabs/MetadataTab.svelte
@@ -1,0 +1,29 @@
+<script>
+  import { currentAgent, agents } from '../../stores.js';
+  import { get } from 'svelte/store';
+
+  function update() {
+    const updated = get(agents).map(a => a.id === $currentAgent.id ? $currentAgent : a);
+    agents.set(updated);
+  }
+</script>
+
+<div class="space-y-4 max-w-xl">
+  <div>
+    <label for="agent-name" class="block text-sm font-medium">Name</label>
+    <input id="agent-name" class="border p-2 w-full" bind:value={$currentAgent.name} on:input={update} />
+  </div>
+  <div>
+    <label for="agent-description" class="block text-sm font-medium">Description</label>
+    <textarea id="agent-description" class="border p-2 w-full" rows="3" bind:value={$currentAgent.description} on:input={update}></textarea>
+  </div>
+  <div>
+    <label for="dataset-type" class="block text-sm font-medium">Dataset Type</label>
+    <select id="dataset-type" class="border p-2 w-full" bind:value={$currentAgent.dataset} on:change={update}>
+      <option value="">Select dataset</option>
+      <option value="SurrealDB">SurrealDB</option>
+      <option value="PostgreSQL">PostgreSQL</option>
+    </select>
+  </div>
+  <button class="bg-blue-500 text-white px-4 py-2 rounded" disabled>Save Changes</button>
+</div>

--- a/src/lib/tabs/MonitoringTab.svelte
+++ b/src/lib/tabs/MonitoringTab.svelte
@@ -1,0 +1,44 @@
+<script>
+  let logs = [
+    { time: '10:00', event: 'Query', details: 'Fetched data' },
+    { time: '10:05', event: 'Error', details: 'Timeout' }
+  ];
+</script>
+
+<div class="space-y-4">
+  <section>
+    <h2 class="font-semibold mb-2">Dashboard</h2>
+    <div class="grid grid-cols-2 gap-4">
+      <div class="border p-4">Usage Chart Placeholder</div>
+      <div class="border p-4">Errors Chart Placeholder</div>
+    </div>
+    <div class="mt-4">
+      <h3 class="font-semibold mb-2">Alerts</h3>
+      <ul class="list-disc pl-4 text-sm">
+        <li>High Latency</li>
+      </ul>
+    </div>
+  </section>
+  <section>
+    <h2 class="font-semibold mb-2">Logs</h2>
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="border-b">
+          <th class="p-1 text-left">Timestamp</th>
+          <th class="p-1 text-left">Event</th>
+          <th class="p-1 text-left">Details</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each logs as l}
+          <tr class="border-b">
+            <td class="p-1">{l.time}</td>
+            <td class="p-1">{l.event}</td>
+            <td class="p-1">{l.details}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+    <button class="mt-2 bg-gray-200 px-2 py-1 rounded">Refresh</button>
+  </section>
+</div>

--- a/src/lib/tabs/QueryingGuidanceTab.svelte
+++ b/src/lib/tabs/QueryingGuidanceTab.svelte
@@ -1,0 +1,38 @@
+<script>
+  let modules = [];
+  const available = ['Rules', 'Examples', 'Constraints'];
+
+  function addModule(name) {
+    modules = [...modules, { name, content: '' }];
+  }
+  function removeModule(i) {
+    modules = modules.filter((_, idx) => idx !== i);
+  }
+  $: compiled = modules.map(m => `### ${m.name}\n${m.content}`).join('\n\n');
+</script>
+
+<div class="flex space-x-4">
+  <div class="w-1/2">
+    <h2 class="font-semibold mb-2">Modules</h2>
+    <div class="flex space-x-2 mb-4">
+      {#each available as a}
+        <button class="bg-gray-200 px-2 py-1 rounded" on:click={() => addModule(a)}>{a}</button>
+      {/each}
+    </div>
+    <ul>
+      {#each modules as m, i}
+        <li class="border p-2 mb-2">
+          <div class="flex justify-between">
+            <span>{m.name}</span>
+            <button class="text-red-500 text-sm" on:click={() => removeModule(i)}>Delete</button>
+          </div>
+          <textarea class="border p-2 w-full mt-2" rows="2" bind:value={m.content}></textarea>
+        </li>
+      {/each}
+    </ul>
+  </div>
+  <div class="w-1/2">
+    <h2 class="font-semibold mb-2">Compiled System Prompt</h2>
+    <textarea class="border p-2 w-full h-full" readonly bind:value={compiled}></textarea>
+  </div>
+</div>

--- a/src/lib/tabs/TestingTab.svelte
+++ b/src/lib/tabs/TestingTab.svelte
@@ -1,0 +1,40 @@
+<script>
+  let prompt = '';
+  let output = '';
+  let logs = [];
+  let showLogs = false;
+  let compare = false;
+
+  function run() {
+    output = `Simulated response for: ${prompt}`;
+    logs = [...logs, `Ran at ${new Date().toLocaleTimeString()}`];
+  }
+</script>
+
+<div class="flex h-full">
+  <div class="w-1/2 p-2 flex flex-col">
+    <textarea class="border p-2 flex-1" bind:value={prompt}></textarea>
+    <button
+      class="bg-blue-500 text-white px-4 py-2 mt-2 self-start"
+      on:click={run}
+    >
+      Run
+    </button>
+    <label class="mt-2 text-sm flex items-center">
+      <input type="checkbox" bind:checked={compare} class="mr-2" />Comparison Mode
+    </label>
+  </div>
+  <div class="w-1/2 p-2 flex flex-col">
+    <div class="border p-2 flex-1 whitespace-pre-wrap">{output}</div>
+    <button class="text-blue-500 text-sm mt-2" on:click={() => (showLogs = !showLogs)}>
+      Toggle Logs
+    </button>
+    {#if showLogs}
+      <div class="border mt-2 p-2 flex-1 overflow-auto">
+        {#each logs as log}
+          <div>{log}</div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+</div>

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,0 +1,22 @@
+import { writable } from 'svelte/store';
+
+export const agents = writable([
+  { id: 1, name: 'Agent 1', description: 'Description', status: 'Active' },
+  { id: 2, name: 'Agent 2', description: 'Description', status: 'Draft' }
+]);
+
+export const currentView = writable('home');
+export const currentAgent = writable(null);
+
+export function createNewAgent() {
+  const id = Date.now();
+  const newAgent = { id, name: 'New Agent', description: '', status: 'Draft' };
+  agents.update(a => [...a, newAgent]);
+  currentAgent.set(newAgent);
+  currentView.set('workspace');
+}
+
+export function openAgent(agent) {
+  currentAgent.set(agent);
+  currentView.set('workspace');
+}


### PR DESCRIPTION
## Summary
- Implement dashboard with sidebar agent list, create button, and reusable library
- Introduce agent workspace with seven configuration and monitoring tabs
- Add tab components for metadata, data integrations, LLM config, guidance, testing, evaluations, and monitoring

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896527460608324a3c90eb5038ef6b6