### PR TITLE
feat: allow deleting agents

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,7 +1,7 @@
 <script>
   import Home from './lib/Home.svelte';
   import AgentWorkspace from './lib/AgentWorkspace.svelte';
-  import { agents, currentView, currentAgent, createNewAgent, openAgent } from './stores.js';
+  import { agents, currentView, currentAgent, createNewAgent, openAgent, deleteAgent } from './stores.js';
 </script>
 
 <div class="flex h-screen">
@@ -13,12 +13,18 @@
       <h2 class="font-semibold mb-2">Agents</h2>
       <ul class="space-y-1">
         {#each $agents as agent}
-          <li>
+          <li class="flex items-center">
             <button
-              class="text-left w-full p-1 rounded hover:bg-gray-200"
+              class="text-left flex-1 p-1 rounded hover:bg-gray-200"
               on:click={() => openAgent(agent)}
             >
               {agent.name}
+            </button>
+            <button
+              class="ml-2 text-red-500 hover:text-red-700"
+              on:click={() => deleteAgent(agent)}
+            >
+              &times;
             </button>
           </li>
         {/each}

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,4 +1,4 @@
-import { writable } from 'svelte/store';
+import { writable, get } from 'svelte/store';
 
 export const agents = writable([
   { id: 1, name: 'Agent 1', description: 'Description', status: 'Active' },
@@ -19,4 +19,13 @@ export function createNewAgent() {
 export function openAgent(agent) {
   currentAgent.set(agent);
   currentView.set('workspace');
+}
+
+export function deleteAgent(agent) {
+  agents.update(a => a.filter(x => x.id !== agent.id));
+  const curr = get(currentAgent);
+  if (curr && curr.id === agent.id) {
+    currentAgent.set(null);
+    currentView.set('home');
+  }
 }


### PR DESCRIPTION
## Summary
- enable removing agents from sidebar
- add store helper to update current view when deleted

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689655289f948324a2b297eeb035a98d