### PR TITLE
feat: add settings tab for agent deletion

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,7 +1,7 @@
 <script>
   import Home from './lib/Home.svelte';
   import AgentWorkspace from './lib/AgentWorkspace.svelte';
-  import { agents, currentView, currentAgent, createNewAgent, openAgent, deleteAgent } from './stores.js';
+  import { agents, currentView, createNewAgent, openAgent } from './stores.js';
 </script>
 
 <div class="flex h-screen">
@@ -19,12 +19,6 @@
               on:click={() => openAgent(agent)}
             >
               {agent.name}
-            </button>
-            <button
-              class="ml-2 text-red-500 hover:text-red-700"
-              on:click={() => deleteAgent(agent)}
-            >
-              &times;
             </button>
           </li>
         {/each}

--- a/src/lib/AgentWorkspace.svelte
+++ b/src/lib/AgentWorkspace.svelte
@@ -7,6 +7,7 @@
   import TestingTab from './tabs/TestingTab.svelte';
   import EvaluationsTab from './tabs/EvaluationsTab.svelte';
   import MonitoringTab from './tabs/MonitoringTab.svelte';
+  import SettingsTab from './tabs/SettingsTab.svelte';
 
   let activeTab = 'Metadata';
 
@@ -17,7 +18,8 @@
     { name: 'Querying Guidance', component: QueryingGuidanceTab, required: false },
     { name: 'Testing', component: TestingTab, required: false },
     { name: 'Evaluations', component: EvaluationsTab, required: false },
-    { name: 'Monitoring', component: MonitoringTab, required: false }
+    { name: 'Monitoring', component: MonitoringTab, required: false },
+    { name: 'Settings', component: SettingsTab, required: false }
   ];
 </script>
 
@@ -60,6 +62,8 @@
           <EvaluationsTab />
         {:else if activeTab === 'Monitoring'}
           <MonitoringTab />
+        {:else if activeTab === 'Settings'}
+          <SettingsTab />
         {/if}
       </div>
       <aside class="w-64 border-l p-4 hidden md:block">

--- a/src/lib/tabs/SettingsTab.svelte
+++ b/src/lib/tabs/SettingsTab.svelte
@@ -1,0 +1,13 @@
+<script>
+  import { currentAgent, deleteAgent } from '../../stores.js';
+</script>
+
+<div class="space-y-4">
+  <h2 class="text-lg font-semibold">Settings</h2>
+  <button
+    class="bg-red-500 text-white px-4 py-2 rounded"
+    on:click={() => deleteAgent($currentAgent)}
+  >
+    Delete Agent
+  </button>
+</div>


### PR DESCRIPTION
## Summary
- remove inline delete action from agent list
- add Settings tab with Delete Agent button
- integrate Settings tab into agent workspace navigation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689664cb5c1c83249ccbf1073827a43e