### PR TITLE
feat: persist agents in local storage

### DIFF
--- a/src/stores.js
+++ b/src/stores.js
@@ -1,9 +1,24 @@
 import { writable, get } from 'svelte/store';
 
-export const agents = writable([
+let initialAgents = [
   { id: 1, name: 'Agent 1', description: 'Description', status: 'Active' },
   { id: 2, name: 'Agent 2', description: 'Description', status: 'Draft' }
-]);
+];
+
+if (typeof localStorage !== 'undefined') {
+  const stored = localStorage.getItem('agents');
+  if (stored) {
+    initialAgents = JSON.parse(stored);
+  }
+}
+
+export const agents = writable(initialAgents);
+
+if (typeof localStorage !== 'undefined') {
+  agents.subscribe(value => {
+    localStorage.setItem('agents', JSON.stringify(value));
+  });
+}
 
 export const currentView = writable('home');
 export const currentAgent = writable(null);


### PR DESCRIPTION
## Summary
- load agent list from localStorage and save updates to persist across sessions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689669c955608324a9a4977ba6119740