### PR TITLE
Use configuration screens in create agent wizard

### DIFF
--- a/docs/agent-creation-tabs.md
+++ b/docs/agent-creation-tabs.md
@@ -2,7 +2,7 @@
 
 This guide walks you through each tab in the agent workspace so you can configure a new agent step by step.
 
-Click **Create New Agent** to launch an interactive walkthrough that guides you through the tabs. After finishing the guide, you'll be taken to the agent workspace.
+Click **Create New Agent** to launch a step-by-step wizard that presents each configuration screen. After finishing, you'll be taken to the agent workspace.
 
 ## Metadata
 Provide the agent name, a short description, and select the dataset type that the agent will work with.

--- a/src/lib/AgentGuide.svelte
+++ b/src/lib/AgentGuide.svelte
@@ -1,44 +1,34 @@
 <script>
   import { currentView, currentAgent } from '../stores.js';
   import { get } from 'svelte/store';
-                                                 
+  import MetadataTab from './tabs/MetadataTab.svelte';
+  import DataIntegrationsTab from './tabs/DataIntegrationsTab.svelte';
+  import LLMConfigTab from './tabs/LLMConfigTab.svelte';
+  import QueryingGuidanceTab from './tabs/QueryingGuidanceTab.svelte';
+  import TestingTab from './tabs/TestingTab.svelte';
+  import EvaluationsTab from './tabs/EvaluationsTab.svelte';
+  import MonitoringTab from './tabs/MonitoringTab.svelte';
+  import SettingsTab from './tabs/SettingsTab.svelte';
+
   let step = 0;
   const steps = [
-    {
-      title: 'Metadata',
-      description: 'Provide the agent name, a short description, and select the dataset type that the agent will work with.'
-    },
-    {
-      title: 'Data Integrations',
-      description: 'Configure the data store connection (e.g., type, host, port, credentials). Add or reuse tools to allow the agent to interact with the data.'
-    },
-    {
-      title: 'LLM Config',
-      description: 'Manage provider credentials and choose the large language model your agent will use. You can create new credentials or reuse existing ones.'
-    },
-    {
-      title: 'Querying Guidance',
-      description: 'Assemble guidance modules such as rules, examples, and constraints. The modules are compiled into a system prompt that steers the agent\'s behavior.'
-    },
-    {
-      title: 'Testing',
-      description: 'Send prompts to the agent and review the simulated responses. Toggle comparison mode and inspect execution logs.'
-    },
-    {
-      title: 'Evaluations',
-      description: 'Create test cases with prompts and expected outputs. Run all test cases to see pass or fail results.'
-    },
-    {
-      title: 'Monitoring',
-      description: 'Review dashboard placeholders for usage and error charts, alerts, and a log table. Refresh logs as needed.'
-    },
-    {
-      title: 'Settings',
-      description: 'Access agent settings, including the ability to delete the agent.'
-    }
+    { title: 'Metadata', component: MetadataTab },
+    { title: 'Data Integrations', component: DataIntegrationsTab },
+    { title: 'LLM Config', component: LLMConfigTab },
+    { title: 'Querying Guidance', component: QueryingGuidanceTab },
+    { title: 'Testing', component: TestingTab },
+    { title: 'Evaluations', component: EvaluationsTab },
+    { title: 'Monitoring', component: MonitoringTab },
+    { title: 'Settings', component: SettingsTab }
   ];
-  function next() { if (step < steps.length - 1) step++; }
-  function prev() { if (step > 0) step--; }
+
+  function next() {
+    if (step < steps.length - 1) step++;
+  }
+
+  function prev() {
+    if (step > 0) step--;
+  }
 
   function finish() {
     if (get(currentAgent)) {
@@ -49,12 +39,12 @@
   }
 </script>
 
-<div class="p-8 max-w-2xl mx-auto">
-  <h1 class="text-2xl font-bold mb-4">Agent Creation Guide</h1>
+<div class="p-8 max-w-4xl mx-auto">
+  <h1 class="text-2xl font-bold mb-4">Create Agent</h1>
   <div class="text-sm text-gray-500 mb-2">Step {step + 1} of {steps.length}</div>
   <div class="mb-6">
-    <h2 class="text-xl font-semibold">{steps[step].title}</h2>
-    <p class="mt-2">{steps[step].description}</p>
+    <h2 class="text-xl font-semibold mb-4">{steps[step].title}</h2>
+    <svelte:component this={steps[step].component} />
   </div>
   <div class="flex justify-between">
     <button on:click={prev} disabled={step === 0} class="bg-gray-200 px-4 py-2 rounded disabled:opacity-50">Back</button>


### PR DESCRIPTION
## Summary
- Replace text-only agent creation guide with sequential configuration screens
- Clarify docs about step-by-step wizard displaying each configuration screen

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68966fc6db248324bd05a41ff413e61c