### PR TITLE
feat: add CoAgent home logo

### DIFF
--- a/public/coagent-logo.svg
+++ b/public/coagent-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="6" fill="#3b82f6"/>
+  <text x="16" y="21" font-size="16" text-anchor="middle" fill="white" font-family="Arial, sans-serif">C</text>
+</svg>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -7,7 +7,9 @@
 
 <div class="flex flex-col h-screen">
   <header class="flex items-center p-4 border-b">
-    <div class="font-bold">Agent Builder</div>
+    <button type="button" on:click={() => currentView.set('home')}>
+      <img src="/coagent-logo.svg" alt="CoAgent" class="h-8" />
+    </button>
     <input type="text" placeholder="Search" class="border p-1 rounded flex-1 mx-4" />
     <div class="rounded-full bg-gray-300 w-8 h-8"></div>
   </header>

--- a/src/lib/Home.svelte
+++ b/src/lib/Home.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <div class="p-8">
-  <h1 class="text-2xl mb-4">Welcome to Agent Builder</h1>
+  <h1 class="text-2xl mb-4">Welcome to CoAgent</h1>
   <button
     class="bg-blue-500 text-white px-4 py-2 rounded mb-8"
     on:click={createNewAgent}


### PR DESCRIPTION
## Summary
- replace text title with clickable CoAgent logo
- update home heading to say CoAgent

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689685461e488324a953cc91bd91d585