### PR TITLE
feat: simplify new agent button

### DIFF
--- a/docs/agent-creation-tabs.md
+++ b/docs/agent-creation-tabs.md
@@ -2,7 +2,7 @@
 
 This guide walks you through each tab in the agent workspace so you can configure a new agent step by step.
 
-Click **Create New Agent** to launch a step-by-step wizard that presents each configuration screen. After finishing, you'll be taken to the agent workspace.
+Click **New Agent** to launch a step-by-step wizard that presents each configuration screen. After finishing, you'll be taken to the agent workspace.
 
 ## Metadata
 Provide the agent name, a short description, and select the dataset type that the agent will work with.

--- a/src/lib/Home.svelte
+++ b/src/lib/Home.svelte
@@ -3,13 +3,25 @@
 </script>
 
 <div class="p-8">
-  <h1 class="text-2xl mb-4">Welcome to CoAgent</h1>
-  <button
-    class="bg-blue-500 text-white px-4 py-2 rounded mb-8"
-    on:click={createNewAgent}
-  >
-    Create New Agent
-  </button>
+  <div class="flex items-center justify-between mb-4">
+    <h1 class="text-2xl">Welcome to CoAgent</h1>
+    <button
+      class="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+      on:click={createNewAgent}
+    >
+      <svg
+        class="h-5 w-5"
+        viewBox="0 0 20 20"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        aria-hidden="true"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" d="M10 4.167v11.666M4.167 10h11.666" />
+      </svg>
+      New Agent
+    </button>
+  </div>
   <h2 class="text-xl mb-2">Recent Agents</h2>
   <div class="grid grid-cols-2 gap-4">
     {#each $agents as agent}


### PR DESCRIPTION
## Summary
- simplify New Agent button with Tailwind styling, move to top-right, add icon
- update documentation to reflect new button label

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896928ba9588324bb5991fc70e39be0