### PR TITLE
feat: make agent tiles responsive

### DIFF
--- a/src/lib/Home.svelte
+++ b/src/lib/Home.svelte
@@ -24,7 +24,7 @@
     </button>
   </div>
   <h2 class="text-xl mb-2">Recent Agents</h2>
-  <div class="grid grid-cols-2 gap-4">
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
     {#each $agents as agent}
       <AgentTile {agent} on:click={() => openAgent(agent)} />
     {/each}


### PR DESCRIPTION
## Summary
- display agent tiles in a responsive grid with up to four tiles per row on large screens

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896975cccb0832490b305b0cbee6d41