### PR TITLE
Move search bar to home page next to new agent

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,8 +10,7 @@
     <button type="button" on:click={() => currentView.set('home')}>
       <img src="/coagent-logo.svg" alt="CoAgent" class="h-8" />
     </button>
-    <input type="text" placeholder="Search" class="border p-1 rounded flex-1 mx-4" />
-    <div class="rounded-full bg-gray-300 w-8 h-8"></div>
+    <div class="rounded-full bg-gray-300 w-8 h-8 ml-auto"></div>
   </header>
   <main class="flex-1 overflow-y-auto">
     {#if $currentView === 'home'}

--- a/src/lib/Home.svelte
+++ b/src/lib/Home.svelte
@@ -6,22 +6,29 @@
 <div class="p-8">
   <div class="flex items-center justify-between mb-4">
     <h1 class="text-2xl">Welcome to CoAgent</h1>
-    <button
-      class="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-      on:click={createNewAgent}
-    >
-      <svg
-        class="h-5 w-5"
-        viewBox="0 0 20 20"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="1.5"
-        aria-hidden="true"
+    <div class="flex items-center gap-4">
+      <input
+        type="text"
+        placeholder="Search"
+        class="border p-1 rounded w-64"
+      />
+      <button
+        class="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+        on:click={createNewAgent}
       >
-        <path stroke-linecap="round" stroke-linejoin="round" d="M10 4.167v11.666M4.167 10h11.666" />
-      </svg>
-      New Agent
-    </button>
+        <svg
+          class="h-5 w-5"
+          viewBox="0 0 20 20"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          aria-hidden="true"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M10 4.167v11.666M4.167 10h11.666" />
+        </svg>
+        New Agent
+      </button>
+    </div>
   </div>
   <h2 class="text-xl mb-2">Recent Agents</h2>
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">


### PR DESCRIPTION
## Summary
- Move search input from global header into the home page next to the **New Agent** button
- Restrict search bar width for a cleaner layout and adjust header spacing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898da0f88188324860ceca654fec7eb