### PR TITLE
Forward click handlers on agent tiles

### DIFF
--- a/src/lib/AgentTile.svelte
+++ b/src/lib/AgentTile.svelte
@@ -2,7 +2,7 @@
   export let agent;
 </script>
 
-<button class="border p-4 rounded hover:bg-gray-50 text-left w-full">
+<button class="border p-4 rounded hover:bg-gray-50 text-left w-full" on:click {...$$restProps}>
   <h3 class="font-semibold">{agent.name}</h3>
   <p class="text-sm">{agent.description}</p>
   <p class="text-xs text-gray-500">Status: {agent.status}</p>


### PR DESCRIPTION
## Summary
- allow AgentTile to forward click events so parent can open agent workspace

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898dc4200308324afeedfe041737e2b