### PR TITLE
Ensure history-based routing removes hash fragments

### DIFF
--- a/src/stores.js
+++ b/src/stores.js
@@ -86,7 +86,7 @@ if (typeof window !== 'undefined') {
     const view = get(currentView);
     const agent = get(currentAgent);
     const path = pathFromState(view, agent);
-    if (window.location.pathname !== path) {
+    if (window.location.pathname !== path || window.location.hash) {
       history.pushState({}, '', path);
     }
   };


### PR DESCRIPTION
## Summary
- Clear any existing URL hash when syncing route state to guarantee history-based routing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898ebf6f028832497912e7e70de665e