### PR TITLE
Remove hash navigation upgrade routine

### DIFF
--- a/src/stores.js
+++ b/src/stores.js
@@ -86,7 +86,7 @@ if (typeof window !== 'undefined') {
     const view = get(currentView);
     const agent = get(currentAgent);
     const path = pathFromState(view, agent);
-    if (window.location.pathname !== path || window.location.hash) {
+    if (window.location.pathname !== path) {
       history.pushState({}, '', path);
     }
   };


### PR DESCRIPTION
## Summary
- Remove leftover hash-based navigation cleanup in `sync`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898f6a298ec8324ac6f49c85efaf84f