### PR TITLE
Switch to history-based routing

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2,7 +2,7 @@
   import Home from './lib/Home.svelte';
   import AgentWorkspace from './lib/AgentWorkspace.svelte';
   import AgentGuide from './lib/AgentGuide.svelte';
-  import { currentView } from './stores.js';
+  import { currentView, currentAgent, setPath } from './stores.js';
 </script>
 
 <div class="flex flex-col h-screen">
@@ -11,9 +11,8 @@
       type="button"
       on:click={() => {
         currentView.set('home');
-        if (typeof window !== 'undefined') {
-          window.location.hash = '';
-        }
+        currentAgent.set(null);
+        setPath('/');
       }}
     >
       <img src="/coagent-logo.svg" alt="CoAgent" class="h-8" />

--- a/src/lib/AgentGuide.svelte
+++ b/src/lib/AgentGuide.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { currentView, currentAgent } from '../stores.js';
+  import { currentView, currentAgent, setPath } from '../stores.js';
   import { get } from 'svelte/store';
   import MetadataTab from './tabs/MetadataTab.svelte';
   import DataIntegrationsTab from './tabs/DataIntegrationsTab.svelte';
@@ -35,9 +35,8 @@
       currentView.set('workspace');
     } else {
       currentView.set('home');
-      if (typeof window !== 'undefined') {
-        window.location.hash = '';
-      }
+      currentAgent.set(null);
+      setPath('/');
     }
   }
 </script>

--- a/src/stores.js
+++ b/src/stores.js
@@ -31,23 +31,25 @@ if (typeof localStorage !== 'undefined') {
 export const currentView = writable('home');
 export const currentAgent = writable(null);
 
+export function setPath(path) {
+  if (typeof window !== 'undefined') {
+    window.history.pushState({}, '', path);
+  }
+}
+
 export function createNewAgent() {
   const id = generateAgentId();
   const newAgent = { id, name: 'New Agent', description: '', status: 'Draft' };
   agents.update(a => [...a, newAgent]);
   currentAgent.set(newAgent);
   currentView.set('guide');
-  if (typeof window !== 'undefined') {
-    window.location.hash = id;
-  }
+  setPath(id);
 }
 
 export function openAgent(agent) {
   currentAgent.set(agent);
   currentView.set('workspace');
-  if (typeof window !== 'undefined') {
-    window.location.hash = agent.id;
-  }
+  setPath(agent.id);
 }
 
 export function deleteAgent(agent) {
@@ -56,8 +58,26 @@ export function deleteAgent(agent) {
   if (curr && curr.id === agent.id) {
     currentAgent.set(null);
     currentView.set('home');
-    if (typeof window !== 'undefined') {
-      window.location.hash = '';
-    }
+    setPath('/');
   }
+}
+
+function handleRoute() {
+  if (typeof window === 'undefined') return;
+  const path = window.location.pathname;
+  const agent = get(agents).find(a => a.id === path);
+  if (agent) {
+    currentAgent.set(agent);
+    if (get(currentView) !== 'guide') {
+      currentView.set('workspace');
+    }
+  } else {
+    currentAgent.set(null);
+    currentView.set('home');
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('popstate', handleRoute);
+  handleRoute();
 }

--- a/src/stores.test.js
+++ b/src/stores.test.js
@@ -7,7 +7,7 @@ let uuidQueue;
 beforeEach(() => {
   vi.resetModules();
   vi.unstubAllGlobals();
-  window.location.hash = '';
+  window.history.replaceState({}, '', '/');
   localStorage.clear();
   uuidQueue = ['init-1', 'init-2', 'new-1', 'new-2'];
   vi.stubGlobal('crypto', {
@@ -32,17 +32,17 @@ describe('agent store', () => {
     expect(ids[0]).not.toBe(ids[1]);
   });
 
-  it('updates current agent and view based on hash', async () => {
+  it('updates current agent and view based on path', async () => {
     const { agents, currentAgent, currentView } = await import('./stores.js');
     const existing = get(agents)[0];
 
-    window.location.hash = existing.id;
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    window.history.pushState({}, '', existing.id);
+    window.dispatchEvent(new PopStateEvent('popstate'));
     expect(get(currentAgent)).toEqual(existing);
     expect(get(currentView)).toBe('workspace');
 
-    window.location.hash = '/agent/invalid';
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    window.history.pushState({}, '', '/agent/invalid');
+    window.dispatchEvent(new PopStateEvent('popstate'));
     expect(get(currentAgent)).toBeNull();
     expect(get(currentView)).toBe('home');
   });


### PR DESCRIPTION
## Summary
- Replace hash navigation with history.pushState via new `setPath` helper
- Sync state with URL using a `popstate` listener
- Update components and tests for path-based routing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898f8d4a4988324a19549b3543a1e7b