### PR TITLE
Add agent timestamps and reverse chronological listing

### DIFF
--- a/src/stores.test.js
+++ b/src/stores.test.js
@@ -7,6 +7,8 @@ let uuidQueue;
 beforeEach(() => {
   vi.resetModules();
   vi.unstubAllGlobals();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2023-01-01T00:00:00Z'));
   window.history.replaceState({}, '', '/');
   localStorage.clear();
   uuidQueue = ['init-1', 'init-2', 'new-1', 'new-2'];
@@ -16,6 +18,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -23,13 +26,17 @@ describe('agent store', () => {
   it('creates unique route-based IDs for new agents', async () => {
     const { createNewAgent, agents } = await import('./stores.js');
     createNewAgent();
+    vi.advanceTimersByTime(1000);
     createNewAgent();
     const allAgents = get(agents);
-    const newAgents = allAgents.slice(-2);
+    const newAgents = allAgents.slice(0, 2);
     const ids = newAgents.map(a => a.id);
     expect(ids[0]).toMatch(/^\/agent\//);
     expect(ids[1]).toMatch(/^\/agent\//);
     expect(ids[0]).not.toBe(ids[1]);
+    expect(new Date(newAgents[0].createdAt).getTime()).toBeGreaterThan(
+      new Date(newAgents[1].createdAt).getTime()
+    );
   });
 
   it('updates current agent and view based on path', async () => {


### PR DESCRIPTION
## Summary
- add `createdAt` timestamp when agents are created
- persist timestamps and keep agents sorted newest first
- test agent ordering and timestamps

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898faf26a7c8324ac4e3c5f7af3f1c9