### PR TITLE
feat: add event log for agent updates

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2,6 +2,7 @@
   import Home from './lib/Home.svelte';
   import AgentWorkspace from './lib/AgentWorkspace.svelte';
   import AgentGuide from './lib/AgentGuide.svelte';
+  import EventLog from './lib/EventLog.svelte';
   import { currentView, currentAgent, setPath } from './stores.js';
 </script>
 
@@ -24,12 +25,17 @@
       <Home />
     {:else if $currentView === 'guide'}
       <AgentGuide />
+    {:else if $currentView === 'log'}
+      <EventLog />
     {:else}
       <AgentWorkspace />
     {/if}
   </main>
   <footer class="p-4 border-t text-sm text-gray-500 flex justify-between">
     <div>Version 0.1</div>
-    <button class="text-blue-500" on:click={() => currentView.set('guide')}>Help</button>
+    <div class="space-x-4">
+      <button class="text-blue-500" on:click={() => currentView.set('log')}>Log</button>
+      <button class="text-blue-500" on:click={() => currentView.set('guide')}>Help</button>
+    </div>
   </footer>
 </div>

--- a/src/lib/EventLog.svelte
+++ b/src/lib/EventLog.svelte
@@ -1,0 +1,24 @@
+<script>
+  import { eventLog } from '../stores.js';
+
+  $: entries = [...$eventLog].sort(
+    (a, b) => new Date(b.timestamp) - new Date(a.timestamp)
+  );
+</script>
+
+<div class="p-8 max-w-3xl mx-auto">
+  <h1 class="text-2xl font-bold mb-4">Event Log</h1>
+  {#if entries.length === 0}
+    <p class="text-gray-500">No events recorded.</p>
+  {:else}
+    <ul class="space-y-2">
+      {#each entries as evt}
+        <li class="border rounded p-2">
+          <div class="text-sm text-gray-500">{new Date(evt.timestamp).toLocaleString()}</div>
+          <div>{evt.action} {evt.agentId}</div>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+

--- a/src/stores.test.js
+++ b/src/stores.test.js
@@ -53,5 +53,15 @@ describe('agent store', () => {
     expect(get(currentAgent)).toBeNull();
     expect(get(currentView)).toBe('home');
   });
+
+  it('logs create and delete events', async () => {
+    const { createNewAgent, deleteAgent, eventLog, agents } = await import('./stores.js');
+    createNewAgent();
+    const newAgent = get(agents).find(a => a.name === 'New Agent');
+    deleteAgent(newAgent);
+    const log = get(eventLog);
+    expect(log[1]).toMatchObject({ action: 'created', agentId: newAgent.id });
+    expect(log[0]).toMatchObject({ action: 'deleted', agentId: newAgent.id });
+  });
 });
 


### PR DESCRIPTION
## Summary
- track agent create/delete operations in a persistent event log
- expose a Log view to display recorded events
- add test ensuring agent actions are logged

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68994fcef1188324bf3c48ff9174da5b