### PR TITLE
Limit page width to match Hugging Face dataset site

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -6,30 +6,36 @@
 </script>
 
 <div class="flex flex-col h-screen">
-  <header class="flex items-center p-4 border-b">
-    <button
-      type="button"
-      on:click={() => {
-        currentView.set('home');
-        currentAgent.set(null);
-        setPath('/');
-      }}
-    >
-      <img src="/coagent-logo.svg" alt="CoAgent" class="h-8" />
-    </button>
-    <div class="rounded-full bg-gray-300 w-8 h-8 ml-auto"></div>
+  <header class="border-b">
+    <div class="flex items-center p-4 w-full max-w-screen-2xl mx-auto">
+      <button
+        type="button"
+        on:click={() => {
+          currentView.set('home');
+          currentAgent.set(null);
+          setPath('/');
+        }}
+      >
+        <img src="/coagent-logo.svg" alt="CoAgent" class="h-8" />
+      </button>
+      <div class="rounded-full bg-gray-300 w-8 h-8 ml-auto"></div>
+    </div>
   </header>
   <main class="flex-1 overflow-y-auto">
-    {#if $currentView === 'home'}
-      <Home />
-    {:else if $currentView === 'guide'}
-      <AgentGuide />
-    {:else}
-      <AgentWorkspace />
-    {/if}
+    <div class="w-full max-w-screen-2xl mx-auto">
+      {#if $currentView === 'home'}
+        <Home />
+      {:else if $currentView === 'guide'}
+        <AgentGuide />
+      {:else}
+        <AgentWorkspace />
+      {/if}
+    </div>
   </main>
-  <footer class="p-4 border-t text-sm text-gray-500 flex justify-between">
-    <div>Version 0.1</div>
-    <button class="text-blue-500" on:click={() => currentView.set('guide')}>Help</button>
+  <footer class="border-t">
+    <div class="p-4 text-sm text-gray-500 flex justify-between w-full max-w-screen-2xl mx-auto">
+      <div>Version 0.1</div>
+      <button class="text-blue-500" on:click={() => currentView.set('guide')}>Help</button>
+    </div>
   </footer>
 </div>


### PR DESCRIPTION
## Summary
- constrain header, main, and footer to a max width mirroring Hugging Face's datasets page
- adjust layout container to use 2xl breakpoint (1536px) for wider displays

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68995072b5588324b20c2b3f5eaf0954