### PR TITLE
Fix footer buttons layout

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -36,9 +36,9 @@
     </div>
   </main>
   <footer class="p-4 border-t">
-    <div class="p-4 text-sm text-gray-500 flex justify-between w-full max-w-screen-2xl mx-auto">
+    <div class="p-4 text-sm text-gray-500 flex justify-between items-center w-full max-w-screen-2xl mx-auto">
       <div>Version 0.1</div>
-      <div class="w-full max-w-screen-2xl mx-auto">
+      <div class="flex gap-2">
         <button class="text-blue-500" on:click={() => currentView.set('log')}>Log</button>
         <button class="text-blue-500" on:click={() => currentView.set('guide')}>Help</button>
       </div>


### PR DESCRIPTION
## Summary
- Align footer version text and buttons using `justify-between`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689956a62ab08324a04cb730a2a344bb