### PR TITLE
Add CoAgent title next to logo

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -19,6 +19,7 @@
       >
         <img src="/coagent-logo.svg" alt="CoAgent" class="h-8" />
       </button>
+      <h1 class="ml-2 text-xl font-semibold">CoAgent</h1>
       <div class="rounded-full bg-gray-300 w-8 h-8 ml-auto"></div>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- show application name in header next to logo for clearer branding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68995c0857e08324830e74fbb1337fb9