### PR TITLE
Enhance chat input with multi-line editor

### DIFF
--- a/src/lib/ChatEditor.svelte
+++ b/src/lib/ChatEditor.svelte
@@ -1,0 +1,47 @@
+<script>
+  import { createEventDispatcher, onMount } from 'svelte';
+  export let value = '';
+  const dispatch = createEventDispatcher();
+  let textarea;
+
+  function send() {
+    if (!value.trim()) return;
+    dispatch('ask');
+  }
+
+  function handleKeydown(e) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      send();
+    }
+  }
+
+  function resize() {
+    if (textarea) {
+      textarea.style.height = 'auto';
+      textarea.style.height = textarea.scrollHeight + 'px';
+    }
+  }
+
+  onMount(resize);
+</script>
+
+<div class="relative w-full">
+  <textarea
+    bind:this={textarea}
+    bind:value
+    rows="1"
+    class="w-full border rounded p-2 pr-16 resize-none"
+    placeholder="Ask your question..."
+    on:input={resize}
+    on:keydown={handleKeydown}
+  />
+  <button
+    type="button"
+    class="absolute right-2 bottom-2 bg-blue-500 text-white px-3 py-1 rounded"
+    on:click={send}
+  >
+    Ask
+  </button>
+</div>
+

--- a/src/lib/Home.svelte
+++ b/src/lib/Home.svelte
@@ -1,4 +1,6 @@
 <script>
+  import ChatEditor from './ChatEditor.svelte';
+
   let input = '';
   let messages = [];
 
@@ -21,7 +23,7 @@
   }
 </script>
 
-<div class="flex flex-col h-full">
+<div class="flex flex-col h-full max-w-2xl mx-auto w-full">
   <h1 class="text-2xl p-8 text-center">What data question do you have?</h1>
   <div class="flex-1 overflow-y-auto p-4 space-y-4">
     {#each messages as msg}
@@ -36,16 +38,7 @@
       </div>
     {/each}
   </div>
-  <form class="p-4 border-t flex" on:submit|preventDefault={send}>
-    <input
-      class="flex-1 border rounded p-2 mr-2"
-      bind:value={input}
-      placeholder="Ask your question..."
-    />
-    <button class="bg-blue-500 text-white px-4 py-2 rounded">Send</button>
-  </form>
+  <div class="p-4 border-t">
+    <ChatEditor bind:value={input} on:ask={send} />
+  </div>
 </div>
-
-<style>
-  form button:disabled { opacity: 0.5; }
-</style>


### PR DESCRIPTION
## Summary
- implement ChatEditor component with auto-resizing textarea and inline Ask button
- use ChatEditor on home page and constrain chat area width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68995eea78e08324bbeca130c91b0b86