### PR TITLE
feat: enlarge chat edit area

### DIFF
--- a/src/lib/ChatEditor.svelte
+++ b/src/lib/ChatEditor.svelte
@@ -30,7 +30,7 @@
   <textarea
     bind:this={textarea}
     bind:value
-    rows="1"
+    rows="4"
     class="w-full border rounded p-2 pr-16 resize-none"
     placeholder="Ask your question..."
     on:input={resize}


### PR DESCRIPTION
## Summary
- expand the chat edit textarea to four lines for easier input

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68996013b438832483d8d72813d12c02