### PR TITLE
Handle ChatEditor input state in Home component

### DIFF
--- a/src/lib/Home.svelte
+++ b/src/lib/Home.svelte
@@ -1,5 +1,19 @@
 <script>
   import { agents, createNewAgent, openAgent } from '../stores.js';
+
+  // Input captured from the ChatEditor component
+  let input = '';
+
+  // Placeholder handler for queries submitted via ChatEditor
+  function send() {
+    if (!input.trim()) return;
+
+    // In a future iteration this could forward the question to a backend
+    console.log('Agent development query:', input);
+
+    // Clear the editor after handling the input
+    input = '';
+  }
 </script>
 
 <div class="p-8">


### PR DESCRIPTION
## Summary
- manage ChatEditor text via new `input` state in Home.svelte
- add `send` handler that logs and clears submitted queries

## Testing
- `npm test` *(fails: expected 'home' to be 'development')*

------
https://chatgpt.com/codex/tasks/task_e_689963d14c788324ae18b8c4d13b2bce