### PR TITLE
Make header logo and text link home

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -20,7 +20,16 @@
       >
         <img src="/coagent-logo.svg" alt="CoAgent" class="h-8" />
       </button>
-       <h1 class="ml-2 text-xl font-semibold">CoAgent</h1>
+      <button
+        class="ml-2 text-xl font-semibold"
+        on:click={() => {
+          currentView.set('home');
+          currentAgent.set(null);
+          setPath('/');
+        }}
+      >
+        CoAgent
+      </button>
       <button
         class="ml-4 text-sm text-gray-600"
         on:click={() => {


### PR DESCRIPTION
## Summary
- Link the CoAgent title to the home view separately from the logo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689968b0e8e08324bb8f9d847ddd5251