### PR TITLE
Rename development view to builder and move menu

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,6 @@
 <script>
   import Home from './lib/Home.svelte';
-  import Development from './lib/Development.svelte';
+  import Builder from './lib/Builder.svelte';
   import AgentWorkspace from './lib/AgentWorkspace.svelte';
   import AgentGuide from './lib/AgentGuide.svelte';
   import EventLog from './lib/EventLog.svelte';
@@ -30,25 +30,27 @@
       >
         CoAgent
       </button>
-      <button
-        class="ml-4 text-sm text-gray-600"
-        on:click={() => {
-          currentView.set('development');
-          currentAgent.set(null);
-          setPath('/development');
-        }}
-      >
-        Development
-      </button>
-      <div class="rounded-full bg-gray-300 w-8 h-8 ml-auto"></div>
+      <div class="ml-auto flex items-center gap-4">
+        <button
+          class="text-sm text-gray-600"
+          on:click={() => {
+            currentView.set('builder');
+            currentAgent.set(null);
+            setPath('/builder');
+          }}
+        >
+          Builder
+        </button>
+        <div class="rounded-full bg-gray-300 w-8 h-8"></div>
+      </div>
     </div>
   </header>
   <main class="flex-1 overflow-y-auto">
     <div class="w-full max-w-screen-2xl mx-auto">
       {#if $currentView === 'home'}
         <Home />
-      {:else if $currentView === 'development'}
-        <Development />
+      {:else if $currentView === 'builder'}
+        <Builder />
       {:else if $currentView === 'guide'}
         <AgentGuide />
       {:else if $currentView === 'log'}

--- a/src/lib/Builder.svelte
+++ b/src/lib/Builder.svelte
@@ -5,7 +5,7 @@
 
 <div class="p-8">
   <div class="flex items-center justify-between mb-4">
-    <h1 class="text-2xl">Agent Development</h1>
+    <h1 class="text-2xl">Agent Builder</h1>
     <div class="flex items-center gap-4">
       <input
         type="text"

--- a/src/stores.js
+++ b/src/stores.js
@@ -109,17 +109,17 @@ export function deleteAgent(agent) {
   const curr = get(currentAgent);
   if (curr && curr.id === agent.id) {
     currentAgent.set(null);
-    currentView.set('development');
-    setPath('/development');
+    currentView.set('builder');
+    setPath('/builder');
   }
 }
 
 function handleRoute() {
   if (typeof window === 'undefined') return;
   const path = window.location.pathname;
-  if (path === '/development') {
+  if (path === '/builder') {
     currentAgent.set(null);
-    currentView.set('development');
+    currentView.set('builder');
     return;
   }
   const agent = get(agents).find(a => a.id === path);

--- a/src/stores.test.js
+++ b/src/stores.test.js
@@ -53,10 +53,10 @@ describe('agent store', () => {
     expect(get(currentAgent)).toBeNull();
     expect(get(currentView)).toBe('home');
 
-    window.history.pushState({}, '', '/development');
+    window.history.pushState({}, '', '/builder');
     window.dispatchEvent(new PopStateEvent('popstate'));
     expect(get(currentAgent)).toBeNull();
-    expect(get(currentView)).toBe('development');
+    expect(get(currentView)).toBe('builder');
   });
 
   it('logs create and delete events', async () => {


### PR DESCRIPTION
## Summary
- Rename the development view to builder across components, routing logic, and tests
- Shift top navigation menu to the right and update button text to Builder

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68996fa833f08324bc1f6c06a45cc42e