### PR TITLE
feat: link builder from editor guide and home page chat

### DIFF
--- a/docs/editor.md
+++ b/docs/editor.md
@@ -1,0 +1,3 @@
+# Editor
+
+- Add your own data integrations in the [Builder](/builder) section.

--- a/src/lib/ChatHome.svelte
+++ b/src/lib/ChatHome.svelte
@@ -45,6 +45,9 @@
     />
     <button class="bg-blue-500 text-white px-4 py-2 rounded">Send</button>
   </form>
+  <div class="p-4 text-center text-sm text-gray-600">
+    Add your own data integrations in the <a href="/builder" class="text-blue-500">Builder</a> section.
+  </div>
   <footer class="p-4 text-sm text-gray-500 flex justify-between">
     <div></div>
     <button class="text-blue-500" on:click={() => currentPage.set('development')}>Development</button>


### PR DESCRIPTION
## Summary
- document editor usage with instructions to add data integrations via [Builder](/builder)
- mention Builder under home page chat window for easy navigation

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689971c7610c8324bbe28a28e2854304