### PR TITLE
feat: add single-page agent creation

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2,7 +2,7 @@
   import Home from './lib/Home.svelte';
   import Builder from './lib/Builder.svelte';
   import AgentWorkspace from './lib/AgentWorkspace.svelte';
-  import AgentGuide from './lib/AgentGuide.svelte';
+  import CreateAgent from './lib/CreateAgent.svelte';
   import EventLog from './lib/EventLog.svelte';
   import { currentView, currentAgent, setPath } from './stores.js';
 </script>
@@ -49,15 +49,15 @@
     <div class="w-full max-w-screen-2xl mx-auto">
       {#if $currentView === 'home'}
         <Home />
-      {:else if $currentView === 'builder'}
-        <Builder />
-      {:else if $currentView === 'guide'}
-        <AgentGuide />
-      {:else if $currentView === 'log'}
-        <EventLog />
-      {:else}
-        <AgentWorkspace />
-      {/if}
+        {:else if $currentView === 'builder'}
+          <Builder />
+        {:else if $currentView === 'create-agent'}
+          <CreateAgent />
+        {:else if $currentView === 'log'}
+          <EventLog />
+        {:else}
+          <AgentWorkspace />
+        {/if}
     </div>
   </main>
   <footer class="px-4 py-2 border-t">

--- a/src/lib/CreateAgent.svelte
+++ b/src/lib/CreateAgent.svelte
@@ -1,0 +1,50 @@
+<script>
+  import { currentAgent, currentView, setPath, openAgent, createNewAgent } from '../stores.js';
+  import MetadataTab from './tabs/MetadataTab.svelte';
+  import DataIntegrationsTab from './tabs/DataIntegrationsTab.svelte';
+  import LLMConfigTab from './tabs/LLMConfigTab.svelte';
+  import { onMount } from 'svelte';
+
+  function cancel() {
+    currentAgent.set(null);
+    currentView.set('builder');
+    setPath('/builder');
+  }
+
+  function save() {
+    if ($currentAgent) {
+      openAgent($currentAgent);
+    }
+  }
+
+  onMount(() => {
+    if (!$currentAgent) {
+      createNewAgent();
+    }
+  });
+</script>
+
+<div class="p-8 max-w-4xl mx-auto space-y-8">
+  <h1 class="text-2xl font-bold">Create Agent</h1>
+
+  <section>
+    <h2 class="text-xl font-semibold mb-2">Metadata</h2>
+    <MetadataTab />
+  </section>
+
+  <section>
+    <h2 class="text-xl font-semibold mb-2">Data Integrations</h2>
+    <DataIntegrationsTab />
+  </section>
+
+  <section>
+    <h2 class="text-xl font-semibold mb-2">LLM Config</h2>
+    <LLMConfigTab />
+  </section>
+
+  <div class="flex justify-end gap-2">
+    <button class="bg-gray-200 px-4 py-2 rounded" on:click={cancel}>Cancel</button>
+    <button class="bg-blue-500 text-white px-4 py-2 rounded" on:click={save}>Save Agent</button>
+  </div>
+</div>
+

--- a/src/stores.js
+++ b/src/stores.js
@@ -93,8 +93,8 @@ export function createNewAgent() {
   agents.update(a => sortAgents([...a, newAgent]));
   logEvent('created', newAgent);
   currentAgent.set(newAgent);
-  currentView.set('guide');
-  setPath(id);
+  currentView.set('create-agent');
+  setPath('/create-agent');
 }
 
 export function openAgent(agent) {
@@ -122,12 +122,14 @@ function handleRoute() {
     currentView.set('builder');
     return;
   }
+  if (path === '/create-agent') {
+    currentView.set('create-agent');
+    return;
+  }
   const agent = get(agents).find(a => a.id === path);
   if (agent) {
     currentAgent.set(agent);
-    if (get(currentView) !== 'guide') {
-      currentView.set('workspace');
-    }
+    currentView.set('workspace');
   } else {
     currentAgent.set(null);
     currentView.set('home');

--- a/src/stores.test.js
+++ b/src/stores.test.js
@@ -53,11 +53,16 @@ describe('agent store', () => {
     expect(get(currentAgent)).toBeNull();
     expect(get(currentView)).toBe('home');
 
-    window.history.pushState({}, '', '/builder');
-    window.dispatchEvent(new PopStateEvent('popstate'));
-    expect(get(currentAgent)).toBeNull();
-    expect(get(currentView)).toBe('builder');
-  });
+      window.history.pushState({}, '', '/builder');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+      expect(get(currentAgent)).toBeNull();
+      expect(get(currentView)).toBe('builder');
+
+      window.history.pushState({}, '', '/create-agent');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+      expect(get(currentAgent)).toBeNull();
+      expect(get(currentView)).toBe('create-agent');
+    });
 
   it('logs create and delete events', async () => {
     const { createNewAgent, deleteAgent, eventLog, agents } = await import('./stores.js');


### PR DESCRIPTION
## Summary
- add `CreateAgent` page consolidating metadata, data integrations, and LLM config
- route `New Agent` to new page and handle `/create-agent` URL
- extend tests for new route handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68997c084b288324ac39035b6c914fe6